### PR TITLE
Issue #29 InvalidBucketAclWithObjectOwnership error

### DIFF
--- a/install/sandbox-accounts-for-events-install.yaml
+++ b/install/sandbox-accounts-for-events-install.yaml
@@ -47,6 +47,9 @@ Resources:
   LoggingBucket:
     Type: 'AWS::S3::Bucket'
     Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
       AccessControl: LogDeliveryWrite
       BucketEncryption: 
         ServerSideEncryptionConfiguration: 


### PR DESCRIPTION
Issue # 29

Add Object Ownership to LoggingBucket definition


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
