### PR TITLE
Migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/amplify/backend/function/AdminQueries4757b5b2/src/cognitoActions.js
+++ b/amplify/backend/function/AdminQueries4757b5b2/src/cognitoActions.js
@@ -12,11 +12,12 @@
  * and limitations under the License.
  */
 
-const { AmplifyUIBuilder } = require('aws-sdk');
-const { CognitoIdentityServiceProvider } = require('aws-sdk');
+
+
+const { CognitoIdentityProvider } = require('@aws-sdk/client-cognito-identity-provider');
 const { v4: uuidv4 } = require('uuid');
 
-const cognitoIdentityServiceProvider = new CognitoIdentityServiceProvider();
+const cognitoIdentityServiceProvider = new CognitoIdentityProvider();
 const userPoolId = process.env.USERPOOL;
 
 async function addUserToGroup(username, groupname) {
@@ -29,7 +30,7 @@ async function addUserToGroup(username, groupname) {
   console.log(`Attempting to add ${username} to ${groupname}`);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminAddUserToGroup(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminAddUserToGroup(params);
     console.log(`Success adding ${username} to ${groupname}`);
     return {
       message: `Success adding ${username} to ${groupname}`,
@@ -50,7 +51,7 @@ async function removeUserFromGroup(username, groupname) {
   console.log(`Attempting to remove ${username} from ${groupname}`);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminRemoveUserFromGroup(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminRemoveUserFromGroup(params);
     console.log(`Removed ${username} from ${groupname}`);
     return {
       message: `Removed ${username} from ${groupname}`,
@@ -69,7 +70,7 @@ async function confirmUserSignUp(username) {
   };
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminConfirmSignUp(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminConfirmSignUp(params);
     console.log(`Confirmed ${username} registration`);
     return {
       message: `Confirmed ${username} registration`,
@@ -87,7 +88,7 @@ async function disableUser(username) {
   };
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminDisableUser(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminDisableUser(params);
     console.log(`Disabled ${username}`);
     return {
       message: `Disabled ${username}`,
@@ -105,7 +106,7 @@ async function enableUser(username) {
   };
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminEnableUser(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminEnableUser(params);
     console.log(`Enabled ${username}`);
     return {
       message: `Enabled ${username}`,
@@ -125,7 +126,7 @@ async function getUser(username) {
   console.log(`Attempting to retrieve information for ${username}`);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminGetUser(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminGetUser(params);
     return result;
   } catch (err) {
     console.log(err);
@@ -143,7 +144,7 @@ async function listUsers(Limit, PaginationToken) {
   console.log('Attempting to list users');
 
   try {
-    const result = await cognitoIdentityServiceProvider.listUsers(params).promise();
+    const result = await cognitoIdentityServiceProvider.listUsers(params);
 
     // Rename to NextToken for consistency with other Cognito APIs
     result.NextToken = result.PaginationToken;
@@ -166,7 +167,7 @@ async function listGroups(Limit, PaginationToken) {
   console.log('Attempting to list groups');
 
   try {
-    const result = await cognitoIdentityServiceProvider.listGroups(params).promise();
+    const result = await cognitoIdentityServiceProvider.listGroups(params);
 
     // Rename to NextToken for consistency with other Cognito APIs
     result.NextToken = result.PaginationToken;
@@ -190,7 +191,7 @@ async function listGroupsForUser(username, Limit, NextToken) {
   console.log(`Attempting to list groups for ${username}`);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminListGroupsForUser(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminListGroupsForUser(params);
     /**
      * We are filtering out the results that seem to be innapropriate for client applications
      * to prevent any informaiton disclosure. Customers can modify if they have the need.
@@ -217,7 +218,7 @@ async function listUsersInGroup(groupname, Limit, NextToken) {
   console.log(`Attempting to list users in group ${groupname}`);
 
   try {
-    const result = await cognitoIdentityServiceProvider.listUsersInGroup(params).promise();
+    const result = await cognitoIdentityServiceProvider.listUsersInGroup(params);
     return result;
   } catch (err) {
     console.log(err);
@@ -235,7 +236,7 @@ async function signUserOut(username) {
   console.log(`Attempting to signout ${username}`);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminUserGlobalSignOut(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminUserGlobalSignOut(params);
     console.log(`Signed out ${username} from all devices`);
     return {
       message: `Signed out ${username} from all devices`,
@@ -265,7 +266,7 @@ async function createUser(username) {
   console.log('Attempting to create user ' + username);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminCreateUser(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminCreateUser(params);
 
     return result;
   } catch (err) {
@@ -283,7 +284,7 @@ async function deleteUser(username) {
   console.log('Attempting to delete user ' + username);
 
   try {
-    const result = await cognitoIdentityServiceProvider.adminDeleteUser(params).promise();
+    const result = await cognitoIdentityServiceProvider.adminDeleteUser(params);
 
     return result;
   } catch (err) {


### PR DESCRIPTION
*Issue #, if available:*

From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

*Description of changes:*

This PR migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.28.2 -t v2-to-v3 amplify/backend/**/*.js
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
