### PR TITLE
remove deprecated service in SCP template

### DIFF
--- a/templates/children-scp.json
+++ b/templates/children-scp.json
@@ -146,7 +146,6 @@
         "mediastore:*",
         "mediatailor:*",
         "mgh:*",
-        "mobilehub:*",
         "mq:*",
         "neptune-db:*",
         "opsworks:*",


### PR DESCRIPTION
aws officially remove mobilehub
https://cloudperceptor.medium.com/aws-has-deprecated-several-products-without-prior-notice-473e16457e46