### PR TITLE
fix codecommit deprecation with github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 # - email: (only for "deploy") Email address of initial admin user to be auto-created 
 # - github_token: (only for "build") Token that will be used to host sandbox-account code (this token must have admin privileges on your github account)
 # - github_owner: (only for "deploy") Github username/organization where the repo will be created
-# - github_reponame: (only for "deploy") (optional) Name of the repo that will be created
 #
 # command syntax: 
 #   make build bucket=[myDeploymentBucket]
@@ -73,7 +72,6 @@ deploy:
 		--parameters ParameterKey=AdminUserEmailInput,ParameterValue=$(email) \
 		             ParameterKey=RepositoryBucket,ParameterValue=$(bucket) \
 					 ParameterKey=GitHubOwner,ParameterValue=$(github_owner) \
-					 ParameterKey=GitHubRepoName,ParameterValue=$(github_reponame) \
 		--capabilities CAPABILITY_IAM $(profileString) \
 		--region $(region); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,14 @@
 # - bucket: S3 bucket for build artifacts (CloudFormation needs permission to access files in this bucket)
 # - profile: (optional) Name of AWS CLI credential profile to use for S3 artifact upload 
 # - email: (only for "deploy") Email address of initial admin user to be auto-created 
+# - github_token: (only for "build") Token that will be used to host sandbox-account code (this token must have admin privileges on your github account)
+# - github_owner: (only for "deploy") Github username/organization where the repo will be created
+# - github_reponame: (only for "deploy") (optional) Name of the repo that will be created
 #
 # command syntax: 
 #   make build bucket=[myDeploymentBucket]
-#   make build bucket=[myDeploymentBucket] profile=[myAwsProfile] branch=[currentDevelopmentBranch]
-#   make deploy bucket=[myDeploymentBucket] email=[myAdminEmailAddress]
+#   make build bucket=[myDeploymentBucket] profile=[myAwsProfile] branch=[currentDevelopmentBranch] github_token=[your_token] 
+#   make deploy bucket=[myDeploymentBucket] email=[myAdminEmailAddress] github_owner=[your_github_username]
 #   make deploy bucket=[myDeploymentBucket] email=[myAdminEmailAddress] profile=[myAwsProfile]
 
 # check if "bucket" parameter is set, otherwise cancel script execution
@@ -31,7 +34,6 @@ branch=main
 $(info Parameter 'branch' has not been set, defaulting to branch 'main'.)
 endif
 
-
 # avoid interferences between "build" folder and "build" command, clear build history
 .PHONY: all build clean
 .SILENT:
@@ -46,6 +48,13 @@ build:
 	cd install/cfn-lambda/dceHandleTerraFormDeployment && zip -FSr ../../../build-cfn/sandbox-accounts-for-events-lambda-terraform.zip . && cd -
 	cd install/cfn-lambda/dceHandleAmplifyDeployment && zip -FSr ../../../build-cfn/sandbox-accounts-for-events-lambda-amplify.zip . && cd -
 
+# create secret that will be used to create github repo
+	if [ -z "$(github_token)" ]; then \
+		echo "*** Missing command line parameter 'github_token=[your_github_token]'.  Stop."; \
+	else \
+		aws secretsmanager describe-secret --secret-id DCE-Github-Token >/dev/null 2>&1 || (aws secretsmanager create-secret --name DCE-Github-Token --description "GitHub OAuth Token" --secret-string "{\"OauthToken\":\"${github_token}\"}" >/dev/null 2>&1 && echo "Secret created successfully.") \
+	fi
+
 # upload build artifacts and CloudFormation template to specified S3 bucket
 	aws s3 sync build-cfn s3://$(bucket) $(profileString)
 	aws s3 cp install/sandbox-accounts-for-events-install.yaml s3://$(bucket)/sandbox-accounts-for-events-install.yaml $(profileString)
@@ -55,12 +64,16 @@ deploy:
 # check if "email" parameter has bet set, else cancel script execution
 	if [ -z "$(email)" ]; then \
 		echo "*** Missing command line parameter 'email=[admin_email_address]'.  Stop."; \
+	elif [ -z "$(github_owner)" ]; then \
+		echo "*** Missing command line parameter 'github_owner=[your_github_username>]'.  Stop."; \
 	else \
 		aws cloudformation create-stack \
 		--stack-name Sandbox-Accounts-for-Events \
 		--template-url https://$(bucket).s3.amazonaws.com/sandbox-accounts-for-events-install.yaml \
 		--parameters ParameterKey=AdminUserEmailInput,ParameterValue=$(email) \
 		             ParameterKey=RepositoryBucket,ParameterValue=$(bucket) \
+					 ParameterKey=GitHubOwner,ParameterValue=$(github_owner) \
+					 ParameterKey=GitHubRepoName,ParameterValue=$(github_reponame) \
 		--capabilities CAPABILITY_IAM $(profileString) \
 		--region $(region); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ delete:
 	aws cloudformation delete-stack \
 	--stack-name Sandbox-Accounts-for-Events $(profileString) \
 	--region $(region)
+	aws secretsmanager delete-secret --secret-id DCE-Github-Token --force-delete-without-recovery --no-cli-pager
+
 
 create-bucket:
 	aws s3 mb s3://$(bucket) --region $(region) $(profileString)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build:
 	if [ -z "$(github_token)" ]; then \
 		echo "*** Missing command line parameter 'github_token=[your_github_token]'.  Stop."; \
 	else \
-		aws secretsmanager describe-secret --secret-id DCE-Github-Token >/dev/null 2>&1 || (aws secretsmanager create-secret --name DCE-Github-Token --description "GitHub OAuth Token" --secret-string "{\"OauthToken\":\"${github_token}\"}" >/dev/null 2>&1 && echo "Secret created successfully.") \
+		aws secretsmanager describe-secret --secret-id DCE-Github-Token $(region) $(profileString) >/dev/null 2>&1 || (aws secretsmanager create-secret --name DCE-Github-Token --description "GitHub OAuth Token" --secret-string "{\"OauthToken\":\"${github_token}\"}" $(region) $(profileString) >/dev/null 2>&1 && echo "Secret created successfully.") \
 	fi
 
 # upload build artifacts and CloudFormation template to specified S3 bucket
@@ -80,7 +80,7 @@ delete:
 	aws cloudformation delete-stack \
 	--stack-name Sandbox-Accounts-for-Events $(profileString) \
 	--region $(region)
-	aws secretsmanager delete-secret --secret-id DCE-Github-Token --force-delete-without-recovery --no-cli-pager
+	aws secretsmanager delete-secret --secret-id DCE-Github-Token --force-delete-without-recovery --no-cli-pager --region $(region) $(profileString)
 
 
 create-bucket:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Prerequisites:
     make build bucket=[your_deployment_bucket_name] github_token=[your_github_token]
     ```
 
-1. Deploy the project into your AWS account. You have to specify the email address of an initial admin user for *Sandbox Accounts for Events*:
+1. Deploy the project into your AWS account. You have to specify the email address of an initial admin user for *Sandbox Accounts for Events* and your github username (shortname) or organisation name :
     ```bash
     make deploy bucket=[your_deployment_bucket_name] email=[email_address_of_admin_user] github_owner=[your_github_username]
     ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Prerequisites:
 * An AWS account, preferably part of AWS Organizations (see recommendations in chapter [Children Accounts](docs/accounts.md))
 * AWS CLI v2 installed
 * GNU make installed
+* [Github personal token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) (with admin_repo and admin_webhook), that will be used to create sandbox repo on github rather than [codecommit (deprecated)](https://horovits.medium.com/disruption-ahead-aws-quietly-axing-services-033e7518eefb)
 
 1. Clone this GitHub repository to your local environment:
     ```bash
@@ -58,19 +59,19 @@ Prerequisites:
 
 1. Build project and upload to newly created S3 bucket:
     ```bash
-    make build bucket=[your_deployment_bucket_name]
+    make build bucket=[your_deployment_bucket_name] github_token=[your_github_token]
     ```
 
 1. Deploy the project into your AWS account. You have to specify the email address of an initial admin user for *Sandbox Accounts for Events*:
     ```bash
-    make deploy bucket=[your_deployment_bucket_name] email=[email_address_of_admin_user]
+    make deploy bucket=[your_deployment_bucket_name] email=[email_address_of_admin_user] github_owner=[your_github_username]
     ```
     The CloudFormation script will now start to create the *Sandbox Accounts for Events* resources in your account, this deployment typically takes about 
     25-30 minutes. It will also generate an initial admin user and send a registration email to the email address you specified in step 5.
 
 1. Go to the CloudFormation page your AWS Console and wait until the stack "Sandbox-Accounts-for-Events" is deployed successfully. Choose this stack, switch to the "Outputs" tab and follow the link right to "AmplifyDomainOutput" to open the *Sandbox Accounts for Events* frontend in your browser. Log in with the email address you provided in step 5 and the one-time password you received via email.
 
-1. By default, *Sandbox Accounts for Events* will create the AWS Amplify application at URL https://main.xxxxxxxxxxxxxx.amplifyapp.com/. If you want to give it a more friendly domain name, follow the steps in [Set up custom domains for AWS Amplify projects](https://docs.aws.amazon.com/amplify/latest/userguide/custom-domains.html)
+1. By default, *Sandbox Accounts for Events* will create the AWS Amplify application at URL https://master.xxxxxxxxxxxxxx.amplifyapp.com/. If you want to give it a more friendly domain name, follow the steps in [Set up custom domains for AWS Amplify projects](https://docs.aws.amazon.com/amplify/latest/userguide/custom-domains.html)
 
 
 ## Deinstalling Sandbox Accounts for Events
@@ -121,7 +122,7 @@ If you experience CloudFormation error messages stating failed deployment/rollba
 
 1. Go to the CloudFormation page your AWS Console. Choose the stack "Sandbox-Accounts-for-Events" (in state DELETE_FAILED) and choose "Delete". Note down the resources that failed deletion, mark them to retain the resources and choose "Delete Stack". The stack should now be deleted successfully.
 
-1. Go to the S3 page in your AWS console and check if all deployment-releated S3 buckets have been deleted properly. If you still find any leftover S3 buckets labelled "amplify-xxxxxx-main-xxxxxx-deployment" or "dce-terraform-state-xxxxxxxx", delete them ("xxxxxx" being a random alphanumeric string).
+1. Go to the S3 page in your AWS console and check if all deployment-releated S3 buckets have been deleted properly. If you still find any leftover S3 buckets labelled "amplify-xxxxxx-master-xxxxxx-deployment" or "dce-terraform-state-xxxxxxxx", delete them ("xxxxxx" being a random alphanumeric string).
 
 1. Clean up your local environment:
     ```bash
@@ -154,4 +155,3 @@ The sample code; software libraries; command line tools; proofs of concept; temp
 
 ---
 Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-

--- a/amplify.yml
+++ b/amplify.yml
@@ -18,11 +18,11 @@ backend:
         - export DCE_ACCOUNTS_TABLE=$(cat terraform.output | jq -r .accounts_table_name.value)
 
         # update Amplify parameter files to connect Amplify frontend with backend
-        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/main/AMPLIFY_function_safeLoginApi_dceApiGw\",\"Value\":\"\\\"${DCE_API_GW}\\\"\",\"Overwrite\":true}"
-        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/main/AMPLIFY_function_safeOperatorApi_dceApiGw\",\"Value\":\"\\\"${DCE_API_GW}\\\"\",\"Overwrite\":true}"
-        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/main/AMPLIFY_function_safeAdminApi_dceApiGw\",\"Value\":\"\\\"${DCE_API_GW}\\\"\",\"Overwrite\":true}"
-        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/main/AMPLIFY_function_safeOperatorApi_dceLeasesTable\",\"Value\":\"\\\"${DCE_LEASES_TABLE}\\\"\",\"Overwrite\":true}"
-        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/main/AMPLIFY_function_safeAdminApi_dceAccountsTable\",\"Value\":\"\\\"${DCE_ACCOUNTS_TABLE}\\\"\",\"Overwrite\":true}"
+        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/master/AMPLIFY_function_safeLoginApi_dceApiGw\",\"Value\":\"\\\"${DCE_API_GW}\\\"\",\"Overwrite\":true}"
+        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/master/AMPLIFY_function_safeOperatorApi_dceApiGw\",\"Value\":\"\\\"${DCE_API_GW}\\\"\",\"Overwrite\":true}"
+        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/master/AMPLIFY_function_safeAdminApi_dceApiGw\",\"Value\":\"\\\"${DCE_API_GW}\\\"\",\"Overwrite\":true}"
+        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/master/AMPLIFY_function_safeOperatorApi_dceLeasesTable\",\"Value\":\"\\\"${DCE_LEASES_TABLE}\\\"\",\"Overwrite\":true}"
+        - aws ssm put-parameter --cli-input-json "{\"Type\":\"String\",\"Name\":\"/amplify/${AWS_APP_ID}/master/AMPLIFY_function_safeAdminApi_dceAccountsTable\",\"Value\":\"\\\"${DCE_ACCOUNTS_TABLE}\\\"\",\"Overwrite\":true}"
         - cat amplify/backend/function/safeAdminApi/parameters.json | jq '.dceApiGw = $var' --arg var $DCE_API_GW > parameters.json
         - cat parameters.json | jq '.dceAccountsTable = $var' --arg var $DCE_ACCOUNTS_TABLE > amplify/backend/function/safeAdminApi/parameters.json
         - cat amplify/backend/function/safeOperatorApi/parameters.json | jq '.dceApiGw = $var' --arg var $DCE_API_GW > parameters.json

--- a/install/cfn-lambda/dceHandleAmplifyDeployment/index.py
+++ b/install/cfn-lambda/dceHandleAmplifyDeployment/index.py
@@ -2,17 +2,27 @@ import boto3
 import os
 import cfnresponse
 import time
+import urllib3
+import json
 
-codecommit_client = boto3.client('codecommit')
+github_api_url = "https://api.github.com"
+github_repo = os.environ['GITHUB_REPO']
+github_branch = os.environ['GITHUB_BRANCH']
+github_token = os.environ['GITHUB_TOKEN']
 amplify_client = boto3.client('amplify')
 amplify_backendclient = boto3.client('amplifybackend')
 s3 = boto3.resource('s3')
 cloudformation_client = boto3.client('cloudformation')
-repo = os.environ['AMPLIFY_REPO']
-branch = os.environ['AMPLIFY_BRANCH']
 app_id = os.environ['AMPLIFY_APP_ID']
 env = os.environ['AMPLIFY_ENV']
 delete_role_arn = os.environ['DELETE_ROLE_ARN']
+
+http = urllib3.PoolManager()
+
+headers = {
+    "Authorization": f"token {github_token}",
+    "Accept": "application/vnd.github.v3+json"
+}
 
 def wait_for_amplify_deployment():
     deployStatus = "PENDING"
@@ -38,22 +48,55 @@ def wait_for_amplify_backend_deletion(stack_name):
             deleteStatus = "DELETE_COMPLETE"
     return deleteStatus
 
+def get_amplify_webhook(app_id, branch):
+    client = boto3.client('amplify')
+    response = client.create_webhook(
+        appId=app_id,
+        branchName=branch,
+        description='Webhook for Amplify branch deployment'
+    )
+    return response['webhook']['webhookUrl']
+
+def create_github_webhook():
+    try:
+        # Créer le webhook entrant sur Amplify et obtenir l'URL
+        amplify_webhook_url = get_amplify_webhook(app_id, env)
+
+        url = f"https://api.github.com/repos/{github_repo}/hooks"
+        headers = {
+            "Authorization": f"token {github_token}",
+            "Accept": "application/vnd.github.v3+json"
+        }
+
+        payload = {
+            "name": "web",
+            "active": True,
+            "events": ["push", "pull_request"],
+            "config": {
+                "url": amplify_webhook_url,
+                "content_type": "json",
+                "insecure_ssl": "0"
+            }
+        }
+
+        response = http.request('POST', url, body=json.dumps(payload), headers=headers)
+        if response.status >= 400:
+            raise Exception(f"Failed to create GitHub webhook: {response.status} {response.data.decode('utf-8')}")
+
+        return {
+            "statusCode": response.status,
+            "body": response.data.decode('utf-8')
+        }
+    except Exception as e:
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": str(e)})
+        }
+
 def handler(event, context):
     if event['RequestType'] == 'Create':
         try:
-            parentCommit = codecommit_client.get_branch(
-                repositoryName=repo,
-                branchName=branch
-            )
-            codecommit_client.create_commit(
-                repositoryName=repo,
-                branchName=branch,
-                parentCommitId = parentCommit['branch']['commitId'],
-                putFiles=[{
-                    'filePath': '/dummy_commit',
-                    'fileContent': ''
-                }]
-            )
+            create_github_webhook()
             print("Amplify deployment successfully started.")
             status = wait_for_amplify_deployment()
             if status == "SUCCEED":

--- a/install/sandbox-accounts-for-events-install.yaml
+++ b/install/sandbox-accounts-for-events-install.yaml
@@ -201,7 +201,7 @@ Resources:
     Properties: 
       RepositoryName: !Ref GitHubRepoName
       RepositoryOwner: !Ref GitHubOwner
-      IsPrivate: false
+      IsPrivate: true
       RepositoryAccessToken: !Ref GitHubToken
       RepositoryDescription: "Amplify-based UI frontend for Sandbox-Accounts-for-Events"
       Code: 

--- a/install/sandbox-accounts-for-events-install.yaml
+++ b/install/sandbox-accounts-for-events-install.yaml
@@ -1,6 +1,21 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
+  GitHubToken:
+    Type: String
+    Description: "GitHub OAuth Token"
+    Default: "{{resolve:secretsmanager:DCE-Github-Token:SecretString:OauthToken}}"
+
+  GitHubOwner:
+    Type: String
+    Description: "GitHub Username or Organization"
+    Default: "awslabs"
+
+  GitHubRepoName:
+    Type: String
+    Description: "GitHub Repository Name"
+    Default: "sandbox-accounts-for-events"
+
   AdminUserEmailInput:
     Type: String
     Description: Email address of admin user for Sandbox Accounts for Events
@@ -12,8 +27,8 @@ Parameters:
     Default: dcerepo
   AmplifyEnvironment:
     Type: String
-    Description: "Environment name for Sandbox Accounts for Events webapp. Keep 'main' unless advised otherwise."
-    Default: main
+    Description: "Environment name for Sandbox Accounts for Events webapp. Keep 'master' unless advised otherwise."
+    Default: master
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -37,10 +52,6 @@ Metadata:
         default: "S3 bucket that holds required source zip files"
       AmplifyEnvironment:
         default: "Name of Amplify environment"
-
-#################
-# DCE TERRAFORM #
-#################
 
 Resources:
 
@@ -185,6 +196,19 @@ Resources:
   # AMPLIFY APP UI #
   ##################
 
+  GitHubRepo:
+    Type: AWS::CodeStar::GitHubRepository
+    Properties: 
+      RepositoryName: !Ref GitHubRepoName
+      RepositoryOwner: !Ref GitHubOwner
+      IsPrivate: false
+      RepositoryAccessToken: !Ref GitHubToken
+      RepositoryDescription: "Amplify-based UI frontend for Sandbox-Accounts-for-Events"
+      Code: 
+        S3: 
+          Bucket: !Ref RepositoryBucket
+          Key: sandbox-accounts-for-events.zip
+
   AppUiAmplifyRole:
     Type: AWS::IAM::Role
     DependsOn: DceCodeBuildTerraformDeployment
@@ -204,10 +228,11 @@ Resources:
 
   AppUiAmplifyApp:
     Type: AWS::Amplify::App
-    DependsOn: DceCodeBuildTerraformDeployment
+    DependsOn: GitHubRepo
     Properties:
       Name: Sandbox-Accounts-for-Events-UI
-      Repository: !GetAtt AppUiAmplifyRepository.CloneUrlHttp
+      Repository: !Sub "https://github.com/${GitHubOwner}/${GitHubRepoName}.git"
+      AccessToken: !Ref GitHubToken
       EnvironmentVariables:
         - Name: ADMIN_USER_EMAIL
           Value: !Ref AdminUserEmailInput
@@ -217,27 +242,16 @@ Resources:
 
   AppUiAmplifyBranch:
     Type: AWS::Amplify::Branch
-    DependsOn: DceCodeBuildTerraformDeployment
+    DependsOn: AppUiAmplifyApp
     Properties:
       BranchName: !Ref AmplifyEnvironment
       AppId: !GetAtt AppUiAmplifyApp.AppId
       EnableAutoBuild: yes
-
-  AppUiAmplifyRepository:
-    Type: AWS::CodeCommit::Repository
-    DependsOn: DceCodeBuildTerraformDeployment
-    Properties:
-      RepositoryName: Sandbox-Accounts-for-Events
-      RepositoryDescription: Amplify-based UI frontend for Sandbox-Accounts-for-Events
-      Code:
-        BranchName: !Ref AmplifyEnvironment
-        S3:
-          Bucket: !Ref RepositoryBucket
-          Key: sandbox-accounts-for-events.zip
+      Stage: PRODUCTION
 
   AppUiTriggerAmplifyDeploymentLambda:
     Type: AWS::Lambda::Function
-    DependsOn: DceCodeBuildTerraformDeployment
+    DependsOn: AppUiAmplifyApp
     Properties:
       Code:
         S3Bucket: !Ref RepositoryBucket
@@ -250,15 +264,16 @@ Resources:
       Timeout: 900
       Environment:
         Variables:
-          AMPLIFY_REPO: !GetAtt AppUiAmplifyRepository.Name
-          AMPLIFY_BRANCH: !GetAtt AppUiAmplifyBranch.BranchName
+          GITHUB_REPO: !Sub "${GitHubOwner}/${GitHubRepoName}"
+          GITHUB_BRANCH: !Ref AmplifyEnvironment
+          GITHUB_TOKEN: !Ref GitHubToken
           AMPLIFY_APP_ID: !GetAtt AppUiAmplifyApp.AppId
           AMPLIFY_ENV: !Ref AmplifyEnvironment
           DELETE_ROLE_ARN: !GetAtt AppUiAmplifyRole.Arn
 
   AppUiTriggerAmplifyDeploymentRole:
     Type: AWS::IAM::Role
-    DependsOn: DceCodeBuildTerraformDeployment
+    DependsOn: AppUiAmplifyApp
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -273,7 +288,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: CodeCommitPolicy
+        - PolicyName: GitHubPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -281,7 +296,7 @@ Resources:
                 Action:
                   - codecommit:GetBranch
                   - codecommit:CreateCommit
-                Resource: !GetAtt AppUiAmplifyRepository.Arn
+                Resource: '*'
         - PolicyName: AmplifyDeletePolicy
           PolicyDocument:
             Version: 2012-10-17
@@ -306,6 +321,16 @@ Resources:
                 Action:
                   - amplify:ListJobs
                 Resource: !Sub arn:aws:amplify:${AWS::Region}:${AWS::AccountId}:apps/${AppUiAmplifyApp.AppId}/branches/${AppUiAmplifyBranch.BranchName}/jobs/*
+        - PolicyName: AmplifyWebhookPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - amplify:CreateWebhook
+                  - amplify:GetWebhook
+                  - amplify:ListWebHooks
+                Resource: !Sub arn:aws:amplify:${AWS::Region}:${AWS::AccountId}:apps/${AppUiAmplifyApp.AppId}/webhooks/*
         - PolicyName: CloudFormationPolicy
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
*Issue #62 *

*Description of changes:*
After the deprecation of the codecommit service by AWS, sandbox-accounts-for-events accounts can no longer be used.
So in this pull request we are changing the SCM from codecommit to github (the recommended alternative).
Major changes:
* the master branch becomes master instead of main because codestar which is used creates repos with master as the master branch
* it is necessary to create a github token so that sandbox-accounts-for-events can create the repo and create the webhook

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
